### PR TITLE
Fixed missing '<' and '>' in message:// scheme

### DIFF
--- a/Support/bin/add
+++ b/Support/bin/add
@@ -12,7 +12,7 @@ File.open(tmpfilename, "w+") do |tmpfile|
   tmpfile.puts(ENV['MM_SUBJECT'])
 
   # Second line contains message URL
-  tmpfile.puts("message://" + CGI::escape(ENV['MM_MESSAGE_ID']))
+  tmpfile.puts("message://" + CGI::escape("<" + ENV['MM_MESSAGE_ID'] + ">"))
 
   detect_path = ENV['MM_SUPPORT_PATH'] + "/bin/detect"
   canonical = $stdin.read


### PR DESCRIPTION
I noticed that Fantastical wasn't importing links correctly, but bundles like Evernote and Omnifocus were. I found the problem, and fixed it. It works on my machine.
